### PR TITLE
Keycloak version bump + documentation improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.3
+FROM quay.io/keycloak/keycloak:24.0.2
 
 COPY dokku-kc.sh /opt/keycloak/bin
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Deploy Keycloak to Dokku
 
 This works for
-- dokku version 0.31
-- keycloak 22.0.1
+- dokku version 0.34.2
+- keycloak 24.0.2
 
 ## Intro
 
@@ -30,10 +30,11 @@ In CLI commands this will look roughly that way
 dokku apps:create keycloak
 dokku config:set keycloak KC_HOSTNAME=keycloak.example.com
 dokku config:set keycloak KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=YOUR_VERY_SECRET_AND_LONG_PASSWORD
+dokku config:set keycloak KC_HTTP_PORT=80 KC_HTTPS_PORT=443
+dokku config:set keycloak KC_PROXY=edge # Nginx manages SSL. No encryption between keycloak and nginx.
 dokku postgres:create keycloakdb
 dokku postgres:link keycloakdb keycloak
 dokku domains:add keycloak keycloak.example.com
-dokku letsencrypt:enable keycloak
 
 # Then let's get the keycloak docker repo
 git clone git@github.com:raphaelbauer/dokku-keycloak.git
@@ -44,4 +45,7 @@ git push dokku
 # Back on your dokku server remove the admin password from the 
 # env variables - they are only needed for the initial startup
 dokku config:unset keycloak KEYCLOAK_ADMIN KEYCLOAK_ADMIN_PASSWORD
+
+# Finally, let's configure SSL:
+dokku letsencrypt:enable keycloak
 ```

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ In CLI commands this will look roughly that way
 dokku apps:create keycloak
 dokku config:set keycloak KC_HOSTNAME=keycloak.example.com
 dokku config:set keycloak KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=YOUR_VERY_SECRET_AND_LONG_PASSWORD
-dokku config:set keycloak KC_HTTP_PORT=80 KC_HTTPS_PORT=443
 dokku config:set keycloak KC_PROXY=edge # Nginx manages SSL. No encryption between keycloak and nginx.
 dokku postgres:create keycloakdb
 dokku postgres:link keycloakdb keycloak
 dokku domains:add keycloak keycloak.example.com
+dokku ports:add keycloak https:443:8443 http:80:8080
 
 # Then let's get the keycloak docker repo
 git clone git@github.com:raphaelbauer/dokku-keycloak.git

--- a/dokku-kc.sh
+++ b/dokku-kc.sh
@@ -19,7 +19,6 @@ then
         echo "[INFO] KC_DB_URL_HOST=$KC_DB_URL_HOST, KC_DB_URL_PORT=$KC_DB_URL_PORT, KC_DB_URL_DATABASE=$KC_DB_URL_DATABASE, KC_DB_USERNAME=$KC_DB_USERNAME, KC_DB_PASSWORD=$KC_DB_PASSWORD"
         
         export KC_DB=postgres
-        export KC_PROXY=edge # Nginx manages SSL. No encryption between keycloak and nginx.
     fi
 
 else


### PR DESCRIPTION
As discussed on Twitter, I have bumped the version of Keycloak and made some improvements to the documentation so that it actually worked for me.

I have moved around the SSL configuration because the application had to be running before it worked. I have also removed the KC_PROXY configuration because I thought it made more sense as it's unrelated to the database.